### PR TITLE
Fixing viewsets for competition to be in line with access control

### DIFF
--- a/coding/routers.py
+++ b/coding/routers.py
@@ -36,7 +36,8 @@ routes.register(r'student/assignment', StudentAssignmentViewSet, basename='stude
 
 # Competition
 
-routes.register(r'competition', CompetitionViewSet, basename='competition')
+routes.register(r'teacher/competition', TeacherCompetitionViewSet, basename='competition')
+routes.register(r'student/competition', StudentCompetitionViewSet, basename='competition')
 routes.register(r'competitionProgress', CompetitionProgressViewSet, basename='competitionProgress')
 
 # STUDENTS

--- a/coding/src/pages/CreateCompetition.js
+++ b/coding/src/pages/CreateCompetition.js
@@ -46,7 +46,7 @@ function CreateCompetition(type = "race") {
       console.log(error);
     });
 
-    axiosService.get(`/api/question/`, {})
+    axiosService.get(`/api/teacher/question/`, {})
     .then((res) => {
       const questionOptions = []
       for (let questionFromApi of res.data) {
@@ -71,7 +71,7 @@ function CreateCompetition(type = "race") {
   const handleCreateCompetition = (values) => {
     console.log(values);
     clearTexts();
-    axiosService.post(`/api/competition/`, { author: userId, name: values.name, questions: values.questions, class: values.class, type: 'R' })
+    axiosService.post(`/api/teacher/competition/`, { author: userId, name: values.name, questions: values.questions, class: values.class, type: 'R' })
     .then((res) => {
       console.log(res);
       setSuccessText("Your competition was created successfully!");

--- a/coding/src/pages/TeacherCompetitionTable.js
+++ b/coding/src/pages/TeacherCompetitionTable.js
@@ -17,7 +17,7 @@ function TeacherCompetitionTable(){
     const user = useSWR(`/api/user/${userId}/`, fetcher);
 
     const fetchLatestCompetitions = () => {
-        axiosService.get(`/api/competition/`, {})
+        axiosService.get(`/api/teacher/competition/`, {})
         .then((response) => {
             count=0
             const newDisplayData = response.data.map((competition) => {


### PR DESCRIPTION
No video on this one.

CreateCompetition was updated to properly pull questions from teacher api.

Viewset for competition was split into 2 one for teacher, one for teacher.  Both added to routers.py

Updated the create and list UI's under teacher view to new api path.

Doesn't look like student has a view to competitions, but the API is ready.