### PR TITLE
Fixing logic to allow students to view questions

### DIFF
--- a/coding/src/pages/Question.js
+++ b/coding/src/pages/Question.js
@@ -42,7 +42,7 @@ class Question extends React.Component {
       parentPage: this.props.assignmentId ? "Assignment" : "Competition",
       name: "",
       description: "",
-      code: "def divisbleByTwo(n):\n",
+      code: "def defaultQuestion - loading(n):\n",
       stderr: "",
       unitTests: [],
       unitTestData: [],

--- a/coding/viewsets.py
+++ b/coding/viewsets.py
@@ -818,15 +818,23 @@ class StudentQuestionViewSet(viewsets.ModelViewSet):
         student = User(id=request.user.id)
         classes = Class.objects.filter(students=student)
         assignmentSet = set()
+        competitionSet = set()
         for clazz in classes:
             for assignment in clazz.assignments.all():
                 assignmentSet.add(assignment.id)
+            for competition in clazz.competitions.all():
+                competitionSet.add(competition.id)
 
         questionSet = set()
         assignments = Assignment.objects.filter(pk__in=assignmentSet)
         for assign in assignments:
-            for question in assign.questions.all():
-                questionSet.add(question.id)
+            for questionWeightPair in assign.questions.all():
+                questionSet.add(questionWeightPair.question.id)
+
+        competitions = Competition.objects.filter(pk__in=competitionSet)
+        for comp in competitions:
+            for questionWeightPair in comp.questions.all():
+                questionSet.add(questionWeightPair.question.id)        
 
         queryset = CodeQuestion.objects.filter(pk__in=questionSet)
 
@@ -840,15 +848,24 @@ class StudentQuestionViewSet(viewsets.ModelViewSet):
         classes = Class.objects.filter(students=student)
         
         assignmentSet = set()
+        competitionSet = set()
+
         for clazz in classes:
             for assignment in clazz.assignments.all():
                 assignmentSet.add(assignment.id)
+            for competition in clazz.competitions.all():
+                competitionSet.add(competition.id)
 
         questionSet = set()
         assignments = Assignment.objects.filter(pk__in=assignmentSet)
         for assign in assignments:
-            for question in assign.questions.all():
-                questionSet.add(question.id)
+            for questionWeightPair in assign.questions.all():
+                questionSet.add(questionWeightPair.question.id)
+
+        competitions = Competition.objects.filter(pk__in=competitionSet)
+        for comp in competitions:
+            for questionWeightPair in comp.questions.all():
+                questionSet.add(questionWeightPair.question.id) 
 
         if int(pk) not in questionSet:
             logger.warn("Got here!")


### PR DESCRIPTION
Issue:

Questions were getting to the Question.js page and seeing a "default" which is the dreaded divisbleByTwo question.  This was occurring as the student was getting a 403 response from the question student endpoint.

The problem was that when checking if a student has access to a question by parsing their list of assignments, we were building up the list of questionWeightPair ids rather than the questionIDs.  Thus, the comparison check was failing.  Secondly, we were not checking the list of questions in competitions at all.

We are now parsing both assignments and competitions and getting the correct ID's.  Note: our naming...mostly my fault, but we are in places referring to lists of questions when we are really checking questionWeightPairs which was the fundamental issue.  Long term this should be fixed.

I have also updated the Question.js page to make it very clear that the page text is default and not a real question, to aid in further issues down the line.